### PR TITLE
Replace import.meta.dirname with standard ESM directory resolution

### DIFF
--- a/internal/run-example.ts
+++ b/internal/run-example.ts
@@ -4,11 +4,15 @@ import { Command } from "commander";
 import path from "path";
 import { readdir } from "fs/promises";
 import { execSync } from "child_process";
+import { fileURLToPath } from "url";
 
 const program = new Command();
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const examplesPath = path.resolve(
-  import.meta.dirname,
+  __dirname,
   "../examples",
 );
 


### PR DESCRIPTION
## What?
Fix compatibility issue in the example runner script by replacing non-standard `import.meta.dirname` with the established ESM directory resolution pattern.

## Why?
Running examples with `pnpm run example v 01` was failing with `TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined` because `import.meta.dirname` is not a standard property in any Node.js version, causing the example path resolution to fail.

## How?
Modified `internal/run-example.ts` to use the standard Node.js ESM pattern for directory resolution:
1. Added import for `fileURLToPath` from the `url` module
2. Converted `import.meta.url` to a file path using `fileURLToPath`
3. Used `path.dirname()` to get the directory

This pattern is the official recommended approach for ESM modules in all Node.js versions that support ES Modules (12.17.0 and later).

## Testing?
Verified the fix by successfully running `pnpm run example v 01`, which now correctly executes the example without errors.