### PR TITLE
Remove quotes around password in `start-redis.sh`

### DIFF
--- a/courses/01-deepsearch-in-typescript/00-apps/01-day-1-app/start-redis.sh
+++ b/courses/01-deepsearch-in-typescript/00-apps/01-day-1-app/start-redis.sh
@@ -39,7 +39,7 @@ source .env
 REDIS_PASSWORD=$(echo "$REDIS_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 REDIS_PORT=$(echo "$REDIS_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 
-if [ "$REDIS_PASSWORD" = "redis-pw" ]; then
+if [ "$REDIS_PASSWORD" == "redis-pw" ]; then
   echo "You are using the default Redis password"
   read -p "Should we generate a random password for you? [y/N]: " -r REPLY
   if ! [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -55,5 +55,5 @@ docker run -d \
   --name $REDIS_CONTAINER_NAME \
   -p "$REDIS_PORT":6379 \
   redis \
-  /bin/sh -c "redis-server --requirepass \"$REDIS_PASSWORD\"" \
+  /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD" \
   && echo "Redis container '$REDIS_CONTAINER_NAME' was successfully created"

--- a/courses/01-deepsearch-in-typescript/00-apps/02-day-3-app/start-redis.sh
+++ b/courses/01-deepsearch-in-typescript/00-apps/02-day-3-app/start-redis.sh
@@ -39,7 +39,7 @@ source .env
 REDIS_PASSWORD=$(echo "$REDIS_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 REDIS_PORT=$(echo "$REDIS_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 
-if [ "$REDIS_PASSWORD" = "redis-pw" ]; then
+if [ "$REDIS_PASSWORD" == "redis-pw" ]; then
   echo "You are using the default Redis password"
   read -p "Should we generate a random password for you? [y/N]: " -r REPLY
   if ! [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -55,5 +55,5 @@ docker run -d \
   --name $REDIS_CONTAINER_NAME \
   -p "$REDIS_PORT":6379 \
   redis \
-  /bin/sh -c "redis-server --requirepass \"$REDIS_PASSWORD\"" \
+  /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD" \
   && echo "Redis container '$REDIS_CONTAINER_NAME' was successfully created"

--- a/courses/01-deepsearch-in-typescript/00-apps/03-day-4-app/start-redis.sh
+++ b/courses/01-deepsearch-in-typescript/00-apps/03-day-4-app/start-redis.sh
@@ -39,7 +39,7 @@ source .env
 REDIS_PASSWORD=$(echo "$REDIS_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 REDIS_PORT=$(echo "$REDIS_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 
-if [ "$REDIS_PASSWORD" = "redis-pw" ]; then
+if [ "$REDIS_PASSWORD" == "redis-pw" ]; then
   echo "You are using the default Redis password"
   read -p "Should we generate a random password for you? [y/N]: " -r REPLY
   if ! [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -55,5 +55,5 @@ docker run -d \
   --name $REDIS_CONTAINER_NAME \
   -p "$REDIS_PORT":6379 \
   redis \
-  /bin/sh -c "redis-server --requirepass \"$REDIS_PASSWORD\"" \
+  /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD" \
   && echo "Redis container '$REDIS_CONTAINER_NAME' was successfully created"

--- a/courses/01-deepsearch-in-typescript/00-apps/04-day-6-app/start-redis.sh
+++ b/courses/01-deepsearch-in-typescript/00-apps/04-day-6-app/start-redis.sh
@@ -39,7 +39,7 @@ source .env
 REDIS_PASSWORD=$(echo "$REDIS_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 REDIS_PORT=$(echo "$REDIS_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 
-if [ "$REDIS_PASSWORD" = "redis-pw" ]; then
+if [ "$REDIS_PASSWORD" == "redis-pw" ]; then
   echo "You are using the default Redis password"
   read -p "Should we generate a random password for you? [y/N]: " -r REPLY
   if ! [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -55,5 +55,5 @@ docker run -d \
   --name $REDIS_CONTAINER_NAME \
   -p "$REDIS_PORT":6379 \
   redis \
-  /bin/sh -c "redis-server --requirepass \"$REDIS_PASSWORD\"" \
+  /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD" \
   && echo "Redis container '$REDIS_CONTAINER_NAME' was successfully created"

--- a/courses/01-deepsearch-in-typescript/00-apps/05-day-8-app/start-redis.sh
+++ b/courses/01-deepsearch-in-typescript/00-apps/05-day-8-app/start-redis.sh
@@ -39,7 +39,7 @@ source .env
 REDIS_PASSWORD=$(echo "$REDIS_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 REDIS_PORT=$(echo "$REDIS_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 
-if [ "$REDIS_PASSWORD" = "redis-pw" ]; then
+if [ "$REDIS_PASSWORD" == "redis-pw" ]; then
   echo "You are using the default Redis password"
   read -p "Should we generate a random password for you? [y/N]: " -r REPLY
   if ! [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -55,5 +55,5 @@ docker run -d \
   --name $REDIS_CONTAINER_NAME \
   -p "$REDIS_PORT":6379 \
   redis \
-  /bin/sh -c "redis-server --requirepass \"$REDIS_PASSWORD\"" \
+  /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD" \
   && echo "Redis container '$REDIS_CONTAINER_NAME' was successfully created"

--- a/courses/01-deepsearch-in-typescript/00-apps/06-final-app/start-redis.sh
+++ b/courses/01-deepsearch-in-typescript/00-apps/06-final-app/start-redis.sh
@@ -39,7 +39,7 @@ source .env
 REDIS_PASSWORD=$(echo "$REDIS_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 REDIS_PORT=$(echo "$REDIS_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 
-if [ "$REDIS_PASSWORD" = "redis-pw" ]; then
+if [ "$REDIS_PASSWORD" == "redis-pw" ]; then
   echo "You are using the default Redis password"
   read -p "Should we generate a random password for you? [y/N]: " -r REPLY
   if ! [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -55,5 +55,5 @@ docker run -d \
   --name $REDIS_CONTAINER_NAME \
   -p "$REDIS_PORT":6379 \
   redis \
-  /bin/sh -c "redis-server --requirepass \"$REDIS_PASSWORD\"" \
+  /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD" \
   && echo "Redis container '$REDIS_CONTAINER_NAME' was successfully created"


### PR DESCRIPTION
Per the discussion on Discord, [node doesn't handle the embedded quotes](https://github.com/nodejs/node/issues/54134) so authentication fails.